### PR TITLE
Fix some code error when compiling

### DIFF
--- a/kernel/timeconst.pl
+++ b/kernel/timeconst.pl
@@ -370,7 +370,7 @@ if ($hz eq '--can') {
 	}
 
 	@val = @{$canned_values{$hz}};
-	if (!defined(@val)) {
+	if (!@val) {
 		@val = compute_values($hz);
 	}
 	output($hz, @val);


### PR DESCRIPTION
From https://stackoverflow.com/questions/41980796/cant-use-definedarray-warning-in-converting-obj-to-h, in line 373 change from if (!defined(@val)) to if (!@val)